### PR TITLE
fix trivial hash collision

### DIFF
--- a/apps/cds/src/cds_storage_riak.erl
+++ b/apps/cds/src/cds_storage_riak.erl
@@ -458,6 +458,7 @@ get_session_data_with_meta(Obj) ->
     end.
 
 assert_card_data_equal([Token | OtherTokens], Hash) ->
+    % TODO same card data could be encrypted with different keys
     FirstData = get_cardholder_data(Token),
     lists:all(
         fun(T) ->


### PR DESCRIPTION
In case when we get hash collision on same data, we can just take first one.